### PR TITLE
Fix example: ensure path passed to mkdir is null-terminated

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,18 +447,21 @@ static class FileUtils
     public unsafe static string CreatePrivateTempDirectory()
     {
         string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-        fixed (byte* pathname = Encoding.UTF8.GetBytes(path))
+
+        int byteLength = Encoding.UTF8.GetByteCount(path) + 1;
+        Span<byte> bytes = byteLength <= 128 ? stackalloc byte[byteLength] : new byte[byteLength];
+        Encoding.UTF8.GetBytes(path, bytes);
+
+        fixed (byte* pathname = bytes)
         {
             int rv = mkdir(pathname, S_IRWXU);
             if (rv == -1)
             {
                 PlatformException.Throw();
             }
-            else
-            {
-                return path;
-            }
         }
+
+        return path;
     }
 }
 ```

--- a/README.md.in
+++ b/README.md.in
@@ -157,18 +157,21 @@ static class FileUtils
     public unsafe static string CreatePrivateTempDirectory()
     {
         string path = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-        fixed (byte* pathname = Encoding.UTF8.GetBytes(path))
+
+        int byteLength = Encoding.UTF8.GetByteCount(path) + 1;
+        Span<byte> bytes = byteLength <= 128 ? stackalloc byte[byteLength] : new byte[byteLength];
+        Encoding.UTF8.GetBytes(path, bytes);
+
+        fixed (byte* pathname = bytes)
         {
             int rv = mkdir(pathname, S_IRWXU);
             if (rv == -1)
             {
                 PlatformException.Throw();
             }
-            else
-            {
-                return path;
-            }
         }
+
+        return path;
     }
 }
 ```


### PR DESCRIPTION
Fixes https://github.com/tmds/Tmds.LibC/issues/31