### PR TITLE
implicit cast to ushort for mode_t

### DIFF
--- a/src/Sources/linux.common/types.cs
+++ b/src/Sources/linux.common/types.cs
@@ -502,6 +502,7 @@ namespace Tmds.Linux
 
         private mode_t(uint value) => __value = value;
 
+        public static implicit operator ushort(mode_t mode_t)=>(ushort)mode_t.Value;
         public static implicit operator mode_t(ushort value) => new mode_t(value);
 
         public override string ToString() => Value.ToString();


### PR DESCRIPTION
There may be a better way to cast the uint that is used internally to a ushort but it should be safe enough since it can be created from ushort