### PR TITLE
Update io_uring

### DIFF
--- a/src/Sources/linux.specific/SizeOf.arch-arm32.cs
+++ b/src/Sources/linux.specific/SizeOf.arch-arm32.cs
@@ -71,5 +71,13 @@ namespace Tmds.Linux
         public static ushort pollfd => 8;
         public static ushort sockaddr_ll => 20;
         public static ushort packet_mreq => 16;
+        public static ushort io_uring_sqe => 64;
+        public static ushort io_uring_cqe => 16;
+        public static ushort io_sqring_offsets => 40;
+        public static ushort io_cqring_offsets => 40;
+        public static ushort io_uring_params => 120;
+        public static ushort io_uring_files_update => 16;
+        public static ushort io_uring_probe_op => 8;
+        public static ushort io_uring_probe => 16;
     }
 }

--- a/src/Sources/linux.specific/SizeOf.arch-arm64.cs
+++ b/src/Sources/linux.specific/SizeOf.arch-arm64.cs
@@ -71,5 +71,13 @@ namespace Tmds.Linux
         public static ushort pollfd => 8;
         public static ushort sockaddr_ll => 20;
         public static ushort packet_mreq => 16;
+        public static ushort io_uring_sqe => 64;
+        public static ushort io_uring_cqe => 16;
+        public static ushort io_sqring_offsets => 40;
+        public static ushort io_cqring_offsets => 40;
+        public static ushort io_uring_params => 120;
+        public static ushort io_uring_files_update => 16;
+        public static ushort io_uring_probe_op => 8;
+        public static ushort io_uring_probe => 16;
     }
 }

--- a/src/Sources/linux.specific/SizeOf.arch-x64.cs
+++ b/src/Sources/linux.specific/SizeOf.arch-x64.cs
@@ -71,5 +71,13 @@ namespace Tmds.Linux
         public static ushort pollfd => 8;
         public static ushort sockaddr_ll => 20;
         public static ushort packet_mreq => 16;
+        public static ushort io_uring_sqe => 64;
+        public static ushort io_uring_cqe => 16;
+        public static ushort io_sqring_offsets => 40;
+        public static ushort io_cqring_offsets => 40;
+        public static ushort io_uring_params => 120;
+        public static ushort io_uring_files_update => 16;
+        public static ushort io_uring_probe_op => 8;
+        public static ushort io_uring_probe => 16;
     }
 }

--- a/test/Tmds.LibC.Tests/StructTests.cs
+++ b/test/Tmds.LibC.Tests/StructTests.cs
@@ -116,7 +116,9 @@ namespace Tmds.Linux.Tests
             "io_sqring_offsets",
             "io_cqring_offsets",
             "io_uring_params",
-            "io_uring_files_update"
+            "io_uring_files_update",
+            "io_uring_probe_op",
+            "io_uring_probe"
         };
 
         [Fact]


### PR DESCRIPTION
following the updates to kernel v5.6.

https://github.com/torvalds/linux/blob/v5.6/include/uapi/linux/io_uring.h

@tmds I marked this as a draft, because I need your input regarding the best handling of zero-length array in the struct `io_uring_probe`: https://github.com/torvalds/linux/blob/7111951b8d4973bda27ff663f2cf18b663d15b48/include/uapi/linux/io_uring.h#L243