### PR TITLE
Add SourceLink, GitVersioning

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,10 +10,12 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
 
     - run: |
         pushd test/Tmds.LibC.Tests && dotnet test && popd
-        dotnet pack src/Tmds.LibC --configuration Release --version-suffix "$(date +"%y%m%d")-$TRAVIS_BUILD_NUMBER" --output .
+        dotnet pack src/Tmds.LibC --configuration Release --output .
 
     - run: |
         curl -H "X-NuGet-ApiKey: ${{ secrets.NUGET_APIKEY }}" -T Tmds.LibC.*.nupkg https://www.myget.org/F/tmds/api/v2/package

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -7,7 +7,6 @@
 
     <Description>Raw bindings to Linux platform APIs for .NET Core.</Description>
     <PackageTags>libc;linux</PackageTags>
-    <VersionPrefix>0.5.0</VersionPrefix>
     <Authors>Tom Deseyn</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Copyright>Tom Deseyn</Copyright>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -9,9 +9,14 @@
     <PackageTags>libc;linux</PackageTags>
     <VersionPrefix>0.5.0</VersionPrefix>
     <Authors>Tom Deseyn</Authors>
-    <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>https://github.com/tmds/Tmds.LibC</RepositoryUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Copyright>Tom Deseyn</Copyright>
+    
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    <PackageReference Include="NerdBank.GitVersioning" Version="3.4.231" PrivateAssets="All" />
+  </ItemGroup>
 </Project>

--- a/src/version.json
+++ b/src/version.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
+    "version": "0.5",
+    "publicReleaseRefSpec": [
+      "^refs/heads/master$"
+    ]
+}

--- a/src/version.json
+++ b/src/version.json
@@ -2,6 +2,6 @@
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
     "version": "0.5",
     "publicReleaseRefSpec": [
-      "^refs/heads/master$"
+      "^refs/tags/v\\d+\\.\\d+\\d+"
     ]
 }


### PR DESCRIPTION
This PR adds two dependencies to improve the tracability of the Tmds.LibC project, in the sense that it should be easier to answer the question: "given a build of Tmds.LibC, in which repository can I find the source commit from which this package was built"?

I know folks can have strong opinions on this. It would be really helpful for us if Tmds.LibC used a mechanism which at least includes the Git commit ID in the final binaries; it's less important which system is used 😄 .

Long story short, this PR:

- Adds SourceLink to the Tmds.LibC project. This:
  * Should make it easier to debug the Tmds.LibC code when consumed as a NuGet package.
  * Embeds the Git repository URL in the NuGet package, removing the need to hard-code it and making it easier to identify builds from forks of the original repository.
- Adds Versioning to the Tmds.LibC project, which:
  * Automaticallys assign a package version number based on the 'git height' (~ number of commits). It also embeds the Git commit id in the assembly's product version attribute, making it easier to correlate a specific version of a NuGet package with a specific commit in the repository. This removes the need to set `--version-suffix "$(date +"%y%m%d")-$TRAVIS_BUILD_NUMBER"` to get a unique package version.
  * Automatically includes a suffix (`-{git commit id}`) to each package which is built off a branch other than `master`, marking it as a pre-release package.
