### PR TITLE
Add canonicalize_file_name from libc

### DIFF
--- a/src/Sources/linux.common/unistd.cs
+++ b/src/Sources/linux.common/unistd.cs
@@ -62,6 +62,8 @@ namespace Tmds.Linux
         public static extern int unlinkat(int dirfd, byte* pathname, int flags);
         [DllImport(libc, SetLastError = true)]
         public static extern int rmdir(byte* pathname);
+        [DllImport(libc, SetLastError = true, CharSet = CharSet.Auto )]
+        public static extern string canonicalize_file_name( string path );
 
         public static int F_OK => 0;
         public static int R_OK => 4;


### PR DESCRIPTION
The .net core Path class can't always do this correctly by itself. I'm using this function in a project, so I figured I'd contribute it here as well.

Confirmed working on x64 and arm64. I don't have am arm32 system to check it on, but the API is the same for this function, so it should work there as well.

String marshalling works, so no need to deal with the byte pointer manually.